### PR TITLE
Rename before_filter -> before_action

### DIFF
--- a/app/controllers/doorkeeper/applications_controller.rb
+++ b/app/controllers/doorkeeper/applications_controller.rb
@@ -3,8 +3,8 @@ module Doorkeeper
     layout 'doorkeeper/admin'
     respond_to :html
 
-    before_filter :authenticate_admin!
-    before_filter :set_application, only: [:show, :edit, :update, :destroy]
+    before_action :authenticate_admin!
+    before_action :set_application, only: [:show, :edit, :update, :destroy]
 
     def index
       @applications = Application.all

--- a/app/controllers/doorkeeper/authorizations_controller.rb
+++ b/app/controllers/doorkeeper/authorizations_controller.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AuthorizationsController < Doorkeeper::ApplicationController
-    before_filter :authenticate_resource_owner!
+    before_action :authenticate_resource_owner!
 
     def new
       if pre_auth.authorizable?

--- a/app/controllers/doorkeeper/authorized_applications_controller.rb
+++ b/app/controllers/doorkeeper/authorized_applications_controller.rb
@@ -1,6 +1,6 @@
 module Doorkeeper
   class AuthorizedApplicationsController < Doorkeeper::ApplicationController
-    before_filter :authenticate_resource_owner!
+    before_action :authenticate_resource_owner!
 
     def index
       @applications = Application.authorized_for(current_resource_owner)

--- a/lib/doorkeeper/helpers/filter.rb
+++ b/lib/doorkeeper/helpers/filter.rb
@@ -5,7 +5,7 @@ module Doorkeeper
         def doorkeeper_for(*args)
           doorkeeper_for = DoorkeeperForBuilder.create_doorkeeper_for(*args)
 
-          before_filter doorkeeper_for.filter_options do
+          before_action doorkeeper_for.filter_options do
             unless valid_token?(doorkeeper_for.scopes)
               if !doorkeeper_token || !doorkeeper_token.accessible?
                 @error = OAuth::InvalidTokenResponse.from_access_token(doorkeeper_token)


### PR DESCRIPTION
`before_filter` will be removed in Rails 5.1. Fixing this removes a large number of deprecation warnings from our logs.