### PR TITLE
Remove ActionController::RackDelegation to support Rails 5

### DIFF
--- a/app/controllers/doorkeeper/application_metal_controller.rb
+++ b/app/controllers/doorkeeper/application_metal_controller.rb
@@ -1,7 +1,6 @@
 module Doorkeeper
   class ApplicationMetalController < ActionController::Metal
     MODULES = [
-      ActionController::RackDelegation,
       ActionController::Instrumentation,
       AbstractController::Rendering,
       ActionController::Rendering,


### PR DESCRIPTION
Rails 5 removes this module, so stop referencing it so we can upgrade.

Inspired by this commit on the upstream doorkeeper gem:
https://github.com/doorkeeper-gem/doorkeeper/commit/02949f966e38