### PR TITLE
Added check for nil refresh_token

### DIFF
--- a/lib/doorkeeper/models/access_token.rb
+++ b/lib/doorkeeper/models/access_token.rb
@@ -25,6 +25,7 @@ module Doorkeeper
     end
 
     def self.by_refresh_token(refresh_token)
+      return nil unless refresh_token
       where(:refresh_token => refresh_token).first
     end
 


### PR DESCRIPTION
We should not return an AccessToken for a `nil` refresh_token.